### PR TITLE
Updated conventions plugin to spring boot 1.3.x

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Build script snippet for use in all Gradle versions:
         }
       }
       dependencies {
-        classpath "gradle.plugin.de.weltn24:spring-boot-conventions:1.1.0"
+        classpath "gradle.plugin.de.weltn24:spring-boot-conventions:1.2.0"
       }
     }
     
@@ -23,7 +23,7 @@ Build script snippet for use in all Gradle versions:
 Build script snippet for new, incubating, plugin mechanism introduced in Gradle 2.1:
 
     plugins {
-      id "de.weltn24.spring-boot-conventions" version "1.1.0"
+      id "de.weltn24.spring-boot-conventions" version "1.2.0"
     }
 
 ## This Plugin adds the following features to your Project:
@@ -34,7 +34,6 @@ Build script snippet for new, incubating, plugin mechanism introduced in Gradle 
 ### Dependencies
 - org.springframework.boot:spring-boot-starter-actuator
 - org.springframework.boot:spring-boot-starter-test
-- io.spring.platform:platform-versions (version: see properties)
 
 ### Configuration
 All configurations are optional
@@ -52,10 +51,6 @@ Example:
 ### Tasks
 - generateBuildProperties : extends application.yml with gradle.properties (generateBuildProperties only exists if "src/main/ressources/config/application.yml" exists)
 - generateGitProperties : creates and fills automatically "resources/main/git.properties"
-
-### Properties (can be changed by modifying gradle.properties in your own project)
-- tomcatVersion : sets version of all org.apache.tomcat.embed (default 8.0.21)
-- springIOVersion : sets version of io.spring.platform:platform-versions (default: 1.1.2.RELEASE)
 
 ### Others
 - if "src/main/ressources/config/application.yml" exists, it will be AUTOMATICALLY extended by gradle.properties (on processResources by generateBuildProperties)

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 apply plugin: "com.gradle.plugin-publish"
 
-version = '1.1.1'
+version = '1.2.0'
 group = 'de.weltn24'
 
 pluginBundle {

--- a/src/main/groovy/de/weltn24/gradle/plugins/SpringBootConventionsPlugin.groovy
+++ b/src/main/groovy/de/weltn24/gradle/plugins/SpringBootConventionsPlugin.groovy
@@ -19,23 +19,8 @@ class SpringBootConventionsPlugin implements Plugin<Project> {
         SpringBootConventionsPluginExtension pluginVariables = project.extensions.create('weltn24SpringBootConventions', SpringBootConventionsPluginExtension)
 
         project.afterEvaluate {
-            final String springIOVersion = project.hasProperty("springIOVersion") ? project.property("springIOVersion") : "1.1.2.RELEASE"
-            final String tomcatVersion = project.hasProperty("tomcatVersion") ? project.property("tomcatVersion") : "8.0.21"
-
             project.dependencies.add(JavaPlugin.COMPILE_CONFIGURATION_NAME, "org.springframework.boot:spring-boot-starter-actuator")
-
             project.dependencies.add(JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME, "org.springframework.boot:spring-boot-starter-test")
-
-            project.dependencies.add("versionManagement", "io.spring.platform:platform-versions:${springIOVersion}@properties")
-
-            project.configurations.all {
-                // enforce a specific version of the embedded tomcat (should match the one of the SDP build pack)
-                resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-                    if (details.requested.group == 'org.apache.tomcat.embed') {
-                        details.useVersion(tomcatVersion)
-                    }
-                }
-            }
         }
 
         if(project.file("src/main/resources/config/application.yml").exists()) {


### PR DESCRIPTION
- removed version management since spring boot uses dependency management plugin in 1.3
- removed tomcat configuration since this can be done using dependency management
